### PR TITLE
create pushToBranchPrefix for creating branch before push

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ release {
   push = false // 'true' would e.g. be useful when triggering the release task on a CI server
   versionSuffix = '-SNAPSHOT' // '.DEV' or '' (empty) could be useful alternatives
   tagPrefix = 'v' // 'r' or '' (empty) could be useful alternatives
+  pushToBranchPrefix = null // empty or null results in pushing to current branch
+                            // nonempty creates new branch before push with name format: "$pushToBranchPrefix-$version-$versionSuffix"
 }
 ```
 

--- a/src/main/groovy/ch/netzwerg/gradle/release/ReleaseExtension.groovy
+++ b/src/main/groovy/ch/netzwerg/gradle/release/ReleaseExtension.groovy
@@ -35,6 +35,7 @@ class ReleaseExtension {
     boolean push = DEFAULT_PUSH
     String tagPrefix = DEFAULT_TAG_PREFIX
     String versionSuffix = DEFAULT_VERSION_SUFFIX
+    String pushToBranchPrefix = null
 
     ReleaseExtension(Project project) {
         this.project = project

--- a/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
+++ b/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
@@ -39,7 +39,7 @@ class ReleaseTask extends DefaultTask {
         releaseExtension.versionFile.text = nextVersion
         commitVersionFile("Prepare next release v$nextVersion", releaseExtension)
         if (releaseExtension.push) {
-            pushChanges(releaseExtension.tagName)
+            pushChanges(releaseExtension)
         }
     }
 
@@ -59,8 +59,17 @@ class ReleaseTask extends DefaultTask {
         "$versionInfo.major.$versionInfo.minor.$nextPatch$suffix" as String
     }
 
-    def pushChanges(String tag) {
-        LOGGER.debug('Pushing changes to repository')
+    def pushChanges(ReleaseExtension releaseExtension) {
+        String branch = releaseExtension.pushToBranchPrefix
+        branch = branch == null || branch.isEmpty() ? null : "$branch-$releaseExtension.versionFile.text"
+        pushChanges(releaseExtension.tagName as String, branch)
+    }
+
+    def pushChanges(String tag, String newBranchName) {
+        LOGGER.debug('Pushing changes to repository' + (newBranchName == null ? "" : " on new branch: $newBranchName"))
+        if (newBranchName != null) {
+            git 'checkout', '-b', newBranchName
+        }
         git 'push', 'origin', tag
         git 'push', 'origin', 'HEAD'
     }


### PR DESCRIPTION
Verison 1.2.4 only exposes the ability to push to the current branch. From a continuous integration server that is monitoring specific branches, you can see how it would be problematic to push to the same branch you're monitoring for more changes as you would continually be building.

My CI tool (and as I understand it, _most_ CI tools) provides the ability to filter branch names. Thus, I'd like to be able to push to a branch that my CI tool does not monitor to avoid the problem altogether.

The following PR does that.