### PR TITLE
Feature/suppress git return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ release {
   push = false // 'true' would e.g. be useful when triggering the release task on a CI server
   versionSuffix = '-SNAPSHOT' // '.DEV' or '' (empty) could be useful alternatives
   tagPrefix = 'v' // 'r' or '' (empty) could be useful alternatives
+  respectGitExitValue = true // defaults to *true*, can be used to ignore the exit value
 }
 ```
 
 **Note:** In multi-projects scenarios, the root project usually does not have a `build` task. Consequently, the
 `release` task will fail with its current default settings. Please use `release.dependsOn subprojects.build`
 (**after** the `subprojects` block) to work around
-[this issue](https://github.com/netzwerg/gradle-release-plugin/issues/19). 
+[this issue](https://github.com/netzwerg/gradle-release-plugin/issues/19).
 
 # Read-Only Properties
 

--- a/src/main/groovy/ch/netzwerg/gradle/release/ReleaseExtension.groovy
+++ b/src/main/groovy/ch/netzwerg/gradle/release/ReleaseExtension.groovy
@@ -26,6 +26,7 @@ class ReleaseExtension {
     private static final DEFAULT_PUSH = false
     private static final DEFAULT_TAG_PREFIX = 'v'
     private static final DEFAULT_VERSION_SUFFIX = '-SNAPSHOT'
+    private static final DEFAULT_RESPECT_GIT_EXIT_VALUE = true
 
     private final Project project
     private final PubChannelContainer channelContainer
@@ -35,6 +36,7 @@ class ReleaseExtension {
     boolean push = DEFAULT_PUSH
     String tagPrefix = DEFAULT_TAG_PREFIX
     String versionSuffix = DEFAULT_VERSION_SUFFIX
+    boolean respectGitExitValue = DEFAULT_RESPECT_GIT_EXIT_VALUE
 
     ReleaseExtension(Project project) {
         this.project = project

--- a/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
+++ b/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
@@ -80,7 +80,7 @@ class ReleaseTask extends DefaultTask {
             LOGGER.debug(gitOutput)
         }
         // check if successful after logging
-        if (releaseExtension.respectGitExitValue) {
+        if (project.getExtensions().getByType(ReleaseExtension.class).respectGitExitValue) {
             result.assertNormalExitValue()
         }
     }

--- a/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
+++ b/src/main/groovy/ch/netzwerg/gradle/release/ReleaseTask.groovy
@@ -80,7 +80,9 @@ class ReleaseTask extends DefaultTask {
             LOGGER.debug(gitOutput)
         }
         // check if successful after logging
-        result.assertNormalExitValue()
+        if (releaseExtension.respectGitExitValue) {
+            result.assertNormalExitValue()
+        }
     }
 
 }


### PR DESCRIPTION
As im having trouble with the git exit status i introduced an option to ignore it.
In my case even when the only output is:

Process 'command 'git'' finished with exit value 1 (state: FAILED)
[18:19:51][:release] 18:19:52.117 [DEBUG] [ch.netzwerg.gradle.release.ReleaseTask] On branch master
[18:19:51][:release] Your branch is up-to-date with 'origin/master'.
[18:19:51][:release] nothing to commit, working directory clean
[18:19:51][:release] 18:19:52.118 [DEBUG] [org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter] Finished executing task ':release'

i get exit-code 1 which let my build fail.

Best regards, Stefan